### PR TITLE
use os.Pipe to avoid blocking

### DIFF
--- a/c/seg.c
+++ b/c/seg.c
@@ -6,6 +6,10 @@ int main(int argc, char* argv[])
     setvbuf(stdout, NULL, _IOLBF, 0);
     setvbuf(stderr, NULL, _IOLBF, 0);
 
+    char buffer[100];
+    fgets(buffer, 100, stdin);
+    printf("From stdin: %s\n", buffer);
+
     printf("C test\n");
     sleep(1);
     printf("1\n");

--- a/gocmd/gocmd.go
+++ b/gocmd/gocmd.go
@@ -1,30 +1,23 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/go-cmd/cmd"
 )
 
-//Dummy reader which does nothing
-type TestReader struct {
-}
-
-//Read get's called by go-cmd
-func (rt *TestReader) Read(p []byte) (n int, err error) {
-	return 0, nil
-}
-
-func NewTestReader() *TestReader {
-	rt := TestReader{}
-	return &rt
-}
-
 func main() {
 	testCmd := cmd.NewCmd("../c/seg")
-	rt := NewTestReader()
-	statusChan := testCmd.StartWithStdin(rt)
+	reader, writer := io.Pipe()
+	go func() {
+		_, _ = io.Copy(writer, bytes.NewBufferString("hello from the other side\n"))
+		// close immediately
+		_ = writer.Close()
+	}()
+	statusChan := testCmd.StartWithStdin(reader)
 
 	ticker := time.NewTicker(1 * time.Second)
 


### PR DESCRIPTION
```
go run gocmd.go
[]
[]
[]
[]
statusChan final state
[From stdin: hello from the other side  C test 1 done]
[]
```